### PR TITLE
Add fuzzy search with Levenshtein distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It scans drives (via NTFS USN journal or generic directory walking), stores file
 - Pluggable scanners for cloud drives (OneDrive/Google Drive/pCloud/Dropbox).
 - Experimental WSL filesystem indexing.
 - Bloom filters for quick name filtering.
+- Fuzzy filename and content search using Levenshtein distance.
 - Command-line tools:
   - `anything.exe index` — build or update the database
   - `search.exe` — query the database with filters (size, date, path, extension, content, author, regex, etc.)

--- a/search.c
+++ b/search.c
@@ -9,6 +9,7 @@
 #include <shlwapi.h>
 #include <inttypes.h>
 #include <ctype.h>
+#include <string.h>
 #pragma comment(lib, "shlwapi.lib")
 
 #include "database.h"
@@ -284,9 +285,14 @@ static DWORD WINAPI filter_worker_thread(void* p){
         char* name = (char*)nv.mv_data;
         if(a->q->ext){ char ext[32]; split_extension_utf8(name, ext, sizeof(ext)); if(_stricmp(ext, a->q->ext)!=0) continue; }
         if(a->q->path_filter){ if(strncmp(parent,a->q->path_filter,strlen(a->q->path_filter))!=0) continue; }
-        if(a->q->name_pattern){ char* tmp=_strdup(name); lowercase_ascii(tmp,strlen(tmp)); char* pat=_strdup(a->q->name_pattern);
-            BOOL ok = (is_avx2_supported() ? avx2_contains(tmp, strlen(tmp), pat, strlen(pat)) : (StrStrIA(tmp, pat)!=NULL));
-            free(tmp); free(pat);
+        if(a->q->name_pattern){
+            char norm[512];
+            normalize_filename_utf8(name, norm, sizeof(norm));
+            char* pat=_strdup(a->q->name_pattern); lowercase_ascii(pat,strlen(pat));
+            for(size_t j=0;pat[j];++j){ if(pat[j]=='_'||pat[j]=='-') pat[j]=' '; }
+            int maxd = (int)((strlen(pat)+4)/5);
+            BOOL ok = fuzzy_match(norm, pat, maxd);
+            free(pat);
             if(!ok) continue;
         }
         if(a->q->content_pattern){
@@ -294,8 +300,12 @@ static DWORD WINAPI filter_worker_thread(void* p){
             MDB_val ck={.mv_data=&r->content_str_id,.mv_size=sizeof(r->content_str_id)}, cv;
             if(mdb_get(txn, dbi_strings, &ck, &cv)!=0) continue;
             char* content = (char*)cv.mv_data;
-            char* tmp=_strdup(content); lowercase_ascii(tmp,strlen(tmp)); char* pat=_strdup(a->q->content_pattern);
-            BOOL ok = StrStrIA(tmp, pat)!=NULL;
+            char* tmp=_strdup(content); lowercase_ascii(tmp,strlen(tmp));
+            for(size_t j=0;tmp[j];++j){ if(tmp[j]=='_'||tmp[j]=='-') tmp[j]=' '; }
+            char* pat=_strdup(a->q->content_pattern); lowercase_ascii(pat,strlen(pat));
+            for(size_t j=0;pat[j];++j){ if(pat[j]=='_'||pat[j]=='-') pat[j]=' '; }
+            int maxd = (int)((strlen(pat)+4)/5);
+            BOOL ok = fuzzy_match(tmp, pat, maxd);
             free(tmp); free(pat);
             if(!ok) continue;
         }
@@ -519,11 +529,14 @@ int wmain(int argc, wchar_t** argv){
         MDB_cursor* cs=NULL; mdb_cursor_open(txn, dbi_strings, &cs);
         MDB_val sk, sv; int rc = mdb_cursor_get(cs, &sk, &sv, MDB_FIRST);
         char* npat = _strdup(q.name_pattern); lowercase_ascii(npat, strlen(npat));
+        for(size_t j=0;npat[j];++j){ if(npat[j]=='_'||npat[j]=='-') npat[j]=' '; }
+        int maxd = (int)((strlen(npat)+4)/5);
         while(rc==0){
             uint64_t sid = *(uint64_t*)sk.mv_data;
             char* name = (char*)sv.mv_data; size_t nlen = sv.mv_size;
-            char* tmp = (char*)_malloca(nlen+1); memcpy(tmp,name,nlen); tmp[nlen]=0; lowercase_ascii(tmp,nlen);
-            if(strstr(tmp, npat)){
+            char* tmp = (char*)_malloca(nlen+1); memcpy(tmp,name,nlen); tmp[nlen]=0;
+            normalize_filename_utf8(tmp,tmp,nlen+1);
+            if(fuzzy_match(tmp, npat, maxd)){
                 MDB_val k={.mv_data=&sid,.mv_size=sizeof(sid)}, v;
                 if(mdb_cursor_get(cix, &k, &v, MDB_SET_KEY)==0){
                     do{ idvec_push(&rec_ids, *(uint64_t*)v.mv_data); } while(mdb_cursor_get(cix, &k, &v, MDB_NEXT_DUP)==0);

--- a/util.c
+++ b/util.c
@@ -2,6 +2,7 @@
 #include "util.h"
 #include <shlwapi.h>
 #include <string.h>
+#include <stdlib.h>
 #include <immintrin.h>
 #include <stdio.h>
 #include <math.h>
@@ -174,4 +175,59 @@ float bm25_score(int tf, int doc_len, float avg_doc_len, int docs_total, int doc
                      ((float)docs_with_term + 0.5f) + 1.0f);
     float denom = (float)tf + k1 * (1.0f - b + b * ((float)doc_len / avg_doc_len));
     return idf * ((float)tf * (k1 + 1.0f) / denom);
+}
+
+int levenshtein_distance(const char* a, size_t alen, const char* b, size_t blen){
+    if(!a) return (int)blen;
+    if(!b) return (int)alen;
+    int* prev=(int*)malloc((blen+1)*sizeof(int));
+    int* curr=(int*)malloc((blen+1)*sizeof(int));
+    if(!prev || !curr){ free(prev); free(curr); return (int)(alen>blen?alen:blen); }
+    for(size_t j=0;j<=blen;j++) prev[j]=(int)j;
+    for(size_t i=0;i<alen;i++){
+        curr[0]=(int)(i+1);
+        for(size_t j=0;j<blen;j++){
+            int cost=(a[i]==b[j])?0:1;
+            int del=prev[j+1]+1;
+            int ins=curr[j]+1;
+            int sub=prev[j]+cost;
+            int m=del<ins?del:ins;
+            if(sub<m) m=sub;
+            curr[j+1]=m;
+        }
+        int* tmp=prev; prev=curr; curr=tmp;
+    }
+    int dist=prev[blen];
+    free(prev); free(curr);
+    return dist;
+}
+
+BOOL fuzzy_match(const char* text, const char* pattern, int max_dist){
+    if(!text || !pattern) return FALSE;
+    size_t n=strlen(text), m=strlen(pattern);
+    if(m==0) return TRUE;
+    if(n<=m){
+        return levenshtein_distance(text, n, pattern, m) <= max_dist;
+    }
+    for(size_t i=0;i<=n-m;i++){
+        size_t win=m + (size_t)max_dist;
+        if(i+win>n) win=n-i;
+        int d=levenshtein_distance(text+i, win, pattern, m);
+        if(d<=max_dist) return TRUE;
+    }
+    return FALSE;
+}
+
+void normalize_filename_utf8(const char* name_utf8, char* out, size_t outcap){
+    if(!name_utf8 || !out || outcap==0){ if(out) out[0]=0; return; }
+    size_t len=strlen(name_utf8); size_t end=len;
+    for(size_t i=len;i>0;i--){ if(name_utf8[i-1]=='.'){ end=i-1; break; } }
+    size_t o=0;
+    for(size_t i=0;i<end && o+1<outcap;i++){
+        char c=name_utf8[i];
+        if(c=='_'||c=='-'||c=='.') c=' ';
+        if(c>='A'&&c<='Z') c=(char)(c-'A'+'a');
+        out[o++]=c;
+    }
+    out[o]=0;
 }

--- a/util.h
+++ b/util.h
@@ -24,6 +24,10 @@ uint64_t hash64(const void* data, size_t len);
 void compute_drive_signature(const wchar_t* drive, uint8_t sig[32]);
 float bm25_score(int tf, int doc_len, float avg_doc_len, int docs_total, int docs_with_term);
 
+int levenshtein_distance(const char* a, size_t alen, const char* b, size_t blen);
+BOOL fuzzy_match(const char* text, const char* pattern, int max_dist);
+void normalize_filename_utf8(const char* name_utf8, char* out, size_t outcap);
+
 // SIMD search
 BOOL is_avx2_supported(void);
 BOOL avx2_contains(const char* haystack, size_t hlen, const char* needle, size_t nlen);


### PR DESCRIPTION
## Summary
- Add Levenshtein-based fuzzy matching utilities
- Integrate fuzzy search for filenames and content terms
- Document fuzzy search capability in README

## Testing
- `gcc -c search.c util.c` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b4382962a4832ca26e1b11c294293d