### PR TITLE
Add plugin architecture for external scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It scans drives (via NTFS USN journal or generic directory walking), stores file
 - Archive content indexing (ZIP/RAR/7z) via libzip.
 - Pluggable scanners for cloud drives (OneDrive/Google Drive/pCloud/Dropbox).
 - Experimental WSL filesystem indexing.
+- Extensible plugin system so third parties can add new scanners.
 - Bloom filters for quick name filtering.
 - Fuzzy filename and content search using Levenshtein distance.
 - Command-line tools:
@@ -35,6 +36,9 @@ Stub scanners exist for OneDrive, Google Drive, and Dropbox. They will use offic
 ## Native WSL File System Indexing
 An experimental scanner illustrates how to traverse and index files stored under the Windows Subsystem for Linux.
 
+## Plugin API
+Custom data source scanners can be implemented as DLLs. Place compiled plugins in a `plugins` folder next to the executable and they will be loaded at startup. The `plugin.h` header documents the API each DLL must expose.
+
 ## Build
 This project is written in **C** for Windows.
 
@@ -44,4 +48,5 @@ This project is written in **C** for Windows.
 
 ### Example Build Command (Visual Studio Developer Command Prompt)
 ```bat
-cl /O2 /MD anything.c database.c exfat.c ntfs.c search.c util.c lmdb.lib shlwapi.lib
+cl /O2 /MD anything.c database.c exfat.c ntfs.c search.c util.c plugin.c lmdb.lib shlwapi.lib
+```

--- a/anything.c
+++ b/anything.c
@@ -20,6 +20,7 @@
 #include "util.h"
 #include "lmdb.h"
 #include "archive.h"
+#include "plugin.h"
 
 // ---- MPMC queue implementation ----
 typedef enum { CONTENT_NONE, CONTENT_TEXT, CONTENT_IFILTER } ContentMode;
@@ -346,6 +347,8 @@ int wmain(int argc, wchar_t** argv){
     if(!MPMC_Init(&ctx.queue, 1<<16)){
         fwprintf(stderr, L"MPMC_Init failed\n"); db_close(db); return 1;
     }
+    PluginHost ph = { &ctx.queue, ctx.cancel_event };
+    Plugin_LoadAll(L"plugins", &ph);
     HANDLE writer = CreateThread(NULL,0,DbWriterThread,&ctx,0,NULL);
 
     HANDLE drive_threads[26]; int drive_count=0;
@@ -377,6 +380,8 @@ int wmain(int argc, wchar_t** argv){
     WaitForMultipleObjects(drive_count, drive_threads, TRUE, INFINITE);
     for(int i=0;i<drive_count;i++) CloseHandle(drive_threads[i]);
 
+    Plugin_ScanAll();
+
     if(args.tail_changes && !args.all_drives){
         HANDLE tailer = StartUSNTailer(args.rootPath, &ctx.queue, ctx.cancel_event);
         if(tailer){
@@ -397,6 +402,7 @@ int wmain(int argc, wchar_t** argv){
             (unsigned long long)header->string_count,
             (unsigned long long)(header->map_size_bytes/1024/1024));
     }
+    Plugin_UnloadAll();
     db_close(db);
     MPMC_Destroy(&ctx.queue);
     CloseHandle(ctx.cancel_event);

--- a/plugin.c
+++ b/plugin.c
@@ -1,0 +1,55 @@
+#include "plugin.h"
+#include <stdio.h>
+
+typedef struct {
+    HMODULE module;
+    AnythingPlugin* api;
+} LoadedPlugin;
+
+static LoadedPlugin g_plugins[16];
+static size_t g_plugin_count = 0;
+static PluginHost g_host;
+
+void Plugin_LoadAll(const wchar_t* dir, PluginHost* host){
+    g_host = *host;
+    wchar_t pattern[MAX_PATH];
+    _snwprintf(pattern, MAX_PATH, L"%s\\*.dll", dir);
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW(pattern, &fd);
+    if(h==INVALID_HANDLE_VALUE) return;
+    do{
+        wchar_t path[MAX_PATH];
+        _snwprintf(path, MAX_PATH, L"%s\\%s", dir, fd.cFileName);
+        HMODULE mod = LoadLibraryW(path);
+        if(!mod) continue;
+        Anything_GetPluginFn getp = (Anything_GetPluginFn)GetProcAddress(mod, "Anything_GetPlugin");
+        if(!getp){ FreeLibrary(mod); continue; }
+        AnythingPlugin* api = getp();
+        if(!api || api->api_version != ANYTHING_PLUGIN_API_VERSION){
+            FreeLibrary(mod); continue;
+        }
+        if(api->init && !api->init(&g_host)){
+            FreeLibrary(mod); continue;
+        }
+        g_plugins[g_plugin_count].module = mod;
+        g_plugins[g_plugin_count].api = api;
+        g_plugin_count++;
+    }while(FindNextFileW(h, &fd) && g_plugin_count < 16);
+    FindClose(h);
+}
+
+void Plugin_ScanAll(void){
+    for(size_t i=0;i<g_plugin_count;i++){
+        if(g_plugins[i].api->scan)
+            g_plugins[i].api->scan();
+    }
+}
+
+void Plugin_UnloadAll(void){
+    for(size_t i=0;i<g_plugin_count;i++){
+        if(g_plugins[i].api->shutdown)
+            g_plugins[i].api->shutdown();
+        FreeLibrary(g_plugins[i].module);
+    }
+    g_plugin_count = 0;
+}

--- a/plugin.h
+++ b/plugin.h
@@ -1,0 +1,28 @@
+#ifndef PLUGIN_H
+#define PLUGIN_H
+
+#include <windows.h>
+#include "anything.h"
+
+#define ANYTHING_PLUGIN_API_VERSION 1
+
+typedef struct PluginHost {
+    MPMCQueue* queue;
+    HANDLE cancel_event;
+} PluginHost;
+
+typedef struct AnythingPlugin {
+    uint32_t api_version;
+    const wchar_t* name;
+    BOOL (*init)(const PluginHost* host);
+    void (*scan)(void);
+    void (*shutdown)(void);
+} AnythingPlugin;
+
+typedef AnythingPlugin* (*Anything_GetPluginFn)(void);
+
+void Plugin_LoadAll(const wchar_t* dir, PluginHost* host);
+void Plugin_ScanAll(void);
+void Plugin_UnloadAll(void);
+
+#endif


### PR DESCRIPTION
## Summary
- introduce stable plugin API and host struct for third-party scanners
- load, execute, and unload scanner DLLs at runtime
- document plugin system and update build command

## Testing
- `x86_64-w64-mingw32-gcc -c plugin.c anything.c database.c exfat.c ntfs.c search.c util.c archive.c wsl.c cloud.c` *(fails: zip.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b441787a44832ca0904ffe26c14d5e